### PR TITLE
chore: cleanup v4

### DIFF
--- a/packages/collecticons-chakra/lib/collecticon-creator.tsx
+++ b/packages/collecticons-chakra/lib/collecticon-creator.tsx
@@ -48,10 +48,8 @@ export function createCollecticon(
     };
     return (
       <Icon {...iconProps} ref={ref}>
-        <svg>
-          {title && <title>{title}</title>}
-          {creatorFn(iconProps)}
-        </svg>
+        {title && <title>{title}</title>}
+        {creatorFn(iconProps)}
       </Icon>
     );
   });

--- a/packages/collecticons-chakra/package.json
+++ b/packages/collecticons-chakra/package.json
@@ -37,8 +37,6 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
-    "@chakra-ui/react": "^3.8.1",
-    "@emotion/react": "^11.14.0",
     "clipboard": "^2.0.11"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,8 +1694,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@devseed-ui/collecticons-chakra@workspace:packages/collecticons-chakra"
   dependencies:
-    "@chakra-ui/react": "npm:^3.8.1"
-    "@emotion/react": "npm:^11.14.0"
     "@types/react": "npm:>=18.0.0"
     "@types/react-dom": "npm:>=18.0.0"
     clipboard: "npm:^2.0.11"


### PR DESCRIPTION
## Summary

Two small cleanups noticed while preparing to consume `@devseed-ui/collecticons-chakra@4` from another repo. Neither is blocking — `4.0.0` is already published to npm and works. Land at your convenience.

- **Remove nested `<svg>` wrapper inside `<Icon>` in `collecticon-creator.tsx`.** Chakra v3's `<Icon>` is itself an `<svg>`, so the inner wrapper was producing `<svg><svg/></svg>` markup in the DOM. Renders fine in practice; React 19 may emit a console warning on the invalid nesting.
- **Move `@chakra-ui/react` and `@emotion/react` from `dependencies` to `peerDependencies` only.** They were listed in both. The duplication can cause consumer trees to install a second copy of Chakra/Emotion alongside the app's, which is the kind of thing that contributes to context-mismatch issues (e.g. duplicate React copies). Peer-only is the conventional shape for UI library packages.

## Test plan
- [x] `ts-check` clean
- [x] `build` succeeds
- [x] Showcase builds + renders icons (visual check via parcel production build)
- [ ] No regressions observed in downstream consumers
